### PR TITLE
Declarative method to force focus using React

### DIFF
--- a/ForceFocusElement.tsx
+++ b/ForceFocusElement.tsx
@@ -1,0 +1,81 @@
+import React, {
+  Children,
+  FunctionComponent, PropsWithChildren, ReactElement,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import ForceFocusWrapper from '../styled/ForceFocusWrapper';
+
+interface ForceFocusProps {
+  isForceFocused: boolean;
+  onFocus: () => void;
+  onBlur: () => void;
+}
+
+const ForceFocus = React.forwardRef<HTMLButtonElement | HTMLInputElement, PropsWithChildren<ForceFocusProps>>(({
+  isForceFocused,
+  onFocus,
+  onBlur,
+  children,
+}, ref) => {
+  const forceFocusRef = useRef<HTMLButtonElement | HTMLInputElement>(null);
+
+  // @ts-ignore
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      onFocus();
+      forceFocusRef?.current?.focus();
+    },
+    blur: () => {
+      onBlur();
+      forceFocusRef?.current?.blur();
+    }
+  }));
+
+  return (
+    <>
+      {Children.count(children) === 1 && Children.map(children, (child) => {
+        if (React.isValidElement(child)) {
+          return (
+            <ForceFocusWrapper isForceFocused={isForceFocused}>
+              {React.cloneElement(child, {
+                ref: forceFocusRef,
+                forwardedRef: forceFocusRef, // vcc-ui-button is passing as ref, vcc-ui-input as forwardedRef
+              })}
+            </ForceFocusWrapper>);
+        }
+        return null;
+      })}
+    </>
+  );
+});
+
+interface ForceFocusElementProps {
+  forwardedRef: React.Ref<HTMLButtonElement | HTMLInputElement>;
+  element: ReactElement;
+}
+
+const ForceFocusElement: FunctionComponent<ForceFocusElementProps> = ({
+  forwardedRef,
+  element,
+}) => {
+  const [isForceFocused, setIsForceFocused] = useState<boolean>(false);
+
+  const onFocusCallback = () => setIsForceFocused(true);
+  const onBlurCallback = () => setIsForceFocused(false);
+
+  return (
+    <ForceFocus
+      ref={forwardedRef}
+      isForceFocused={isForceFocused}
+      onFocus={onFocusCallback}
+      onBlur={onBlurCallback}
+    >
+      {element}
+    </ForceFocus>
+  );
+};
+
+export default ForceFocusElement;

--- a/ForceFocusWrapper.tsx
+++ b/ForceFocusWrapper.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const ForceFocusWrapper = styled.span<{ isForceFocused: boolean }>`
+  outline: ${({ isForceFocused, theme }) => (isForceFocused ? theme.focusOutline : 'none')};
+`;
+
+export default ForceFocusWrapper;

--- a/PseudocodeUse.tsx
+++ b/PseudocodeUse.tsx
@@ -1,0 +1,34 @@
+import React, { useRef } from 'react';
+import ForceFocusElement from './ForceFocusElement';
+
+const Pseudo: FunctionComponent = () => {
+  const localButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    // if isKeyboardNavigationMode
+    localButtonRef.current?.focus() // will trigger the focus code
+  }, [])
+
+  const whenYouLike = () => localButtonRef.current?.blur() // will trigger the blur code
+  
+  const handleOnClick = () => whenYouLike();
+
+  return (
+    <ForceFocusElement
+        forwardedRef={localButtonRef}
+        element={(
+            <Button
+                testId="record-voice-message-step-button-call"
+                variant={ButtonVariant.Success}
+                isCircular
+                isDisabled={!stepStatuses.callStep.isActive}
+                onClick={handleOnClick}
+            >
+                <PhoneRingingIcon
+                    color={theme.icon02}
+                    size={theme.iconSize2xs}
+                />
+            </Button>
+        )}
+    />)
+};


### PR DESCRIPTION
This is something I came up with that avoids code such as classnames and IDs, using refs and React tools instead. Apart from TypeScript fuss, it should work for other components not just button.

Basically by calling focus()/ blur() on our local ref, which we pass down until its overridden, we can change the styles and focus the element (we can actually use any name for the functions we want to override in useImperativeHandle React hook, then call them in our code. Not just override native named ones)

A work in progress if you think of a better solution

N.B useImperativeHandle causes no state change/ re-render. So the additional level of isForceFocused prop makes the render happen